### PR TITLE
Correct Help Text for UTF-16 Big Endian Encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Available encoders:
   urlencode         - URL encode reserved characters
   urlencodeall      - URL encode all characters
   utf16             - UTF-16 encoder (Little Endian)
-  utf16be           - UTF-16 encoder (Little Endian)
+  utf16be           - UTF-16 encoder (Big Endian)
 ```
 
 To urlencode, base64encode and hex encode a string:

--- a/pkg/pencode/utf16beencoder.go
+++ b/pkg/pencode/utf16beencoder.go
@@ -21,5 +21,5 @@ func (u UTF16BEEncode) Encode(input []byte) ([]byte, error) {
 }
 
 func (u UTF16BEEncode) HelpText() string {
-	return "UTF-16 encoder (Little Endian)"
+	return "UTF-16 encoder (Big Endian)"
 }


### PR DESCRIPTION
Fix a couple of copy-and-paste typos