### PR TITLE
Fix zsh autocompletion

### DIFF
--- a/pencode-completion.zsh
+++ b/pencode-completion.zsh
@@ -1,5 +1,5 @@
 compdef _pencode pencode
 
 function _pencode {
-    _arguments "1: :($(pencode -list))"
+    _arguments "*: :($(pencode -list))"
 }


### PR DESCRIPTION
Fix zsh autocompletion for many encoders (instead of just the first one).