### PR TITLE
Add input wordlist functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ pencode - complex payload encoder v0.3
 
 Usage: ./pencode FUNC1 FUNC2 FUNC3...
 
-./pencode reads input from stdin, which is typically piped from another process.
+./pencode reads input from stdin by default, which is typically piped from another process.
+
+OPTIONS:
+-input reads input from a file, line by line.
 
 ENCODERS
   b64encode         - Base64 encoder


### PR DESCRIPTION
This pull request adds the ability to pass `pencode` an input wordlist, rather than only accepting input via stdin.

The use case here is when fuzzing something like a JSON or SOAP API with predefined wordlists and ffuf/intruder/whatever. I'd like to be able to pass my attack wordlist to `pencode` directly, and have it spit out the encoded/escaped versions of the payloads that I can subsequently use to fuzz a specific target without unintentionally breaking the JSON/XML encoder.