### PR TITLE
Add HTML encoding escape and unescape

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ OPTIONS:
 ENCODERS
   b64encode         - Base64 encoder
   hexencode         - Hex string encoder
+  htmlescape        - HTML escape
   jsonescape        - JSON escape
   unicodeencodeall  - Unicode escape string encode (all characters)
   urlencode         - URL encode reserved characters
@@ -37,6 +38,7 @@ ENCODERS
 DECODERS
   b64decode         - Base64 decoder
   hexdecode         - Hex string decoder
+  htmlunescape      - HTML unescape
   jsonunescape      - JSON unescape
   unicodedecode     - Unicode escape string decode
   urldecode         - URL decode

--- a/pkg/pencode/encoders.go
+++ b/pkg/pencode/encoders.go
@@ -12,6 +12,8 @@ var availableEncoders = map[string]Encoder{
 	"filename.tmpl":    Template{},
 	"hexencode":        HexEncoder{},
 	"hexdecode":        HexDecoder{},
+	"htmlescape":       HTMLEscaper{},
+	"htmlunescape":     HTMLUnescaper{},
 	"jsonescape":       JSONEscaper{},
 	"jsonunescape":     JSONUnescaper{},
 	"lower":            StrToLower{},
@@ -44,8 +46,8 @@ func NewChain() *Chain {
 	return &c
 }
 
-//Initialize loops through requested names for encoders and sets up the encoder chain. If an unknown encoder is
-//requested, error will be returned.
+// Initialize loops through requested names for encoders and sets up the encoder chain. If an unknown encoder is
+// requested, error will be returned.
 func (c *Chain) Initialize(actions []string) error {
 	c.actions = actions
 	c.Encoders = make([]Encoder, 0)
@@ -85,7 +87,7 @@ func (c *Chain) Encode(input []byte) ([]byte, error) {
 	return input, nil
 }
 
-//HasEncoder returns true if encoder with a specified name is configured
+// HasEncoder returns true if encoder with a specified name is configured
 func (c *Chain) HasEncoder(name string) (bool, error) {
 	if _, ok := availableEncoders[name]; ok {
 		return true, nil
@@ -107,7 +109,7 @@ func (c *Chain) GetEncoders() []string {
 	return names
 }
 
-//Usage prints the help string for each  configured encoder
+// Usage prints the help string for each  configured encoder
 func (c *Chain) Usage() {
 	// Calculate maximum keyword length for nice help formatting
 	max_length := 0

--- a/pkg/pencode/htmldecode.go
+++ b/pkg/pencode/htmldecode.go
@@ -1,0 +1,19 @@
+package pencode
+
+import "html"
+
+type HTMLUnescaper struct{}
+
+func (u HTMLUnescaper) Encode(input []byte) ([]byte, error) {
+	out := html.UnescapeString(string(input))
+
+	return []byte(out), nil
+}
+
+func (u HTMLUnescaper) HelpText() string {
+	return "HTML unescape"
+}
+
+func (u HTMLUnescaper) Type() string {
+	return "decoders"
+}

--- a/pkg/pencode/htmlencode.go
+++ b/pkg/pencode/htmlencode.go
@@ -1,0 +1,19 @@
+package pencode
+
+import "html"
+
+type HTMLEscaper struct{}
+
+func (u HTMLEscaper) Encode(input []byte) ([]byte, error) {
+	out := html.EscapeString(string(input))
+
+	return []byte(out), nil
+}
+
+func (u HTMLEscaper) HelpText() string {
+	return "HTML escape"
+}
+
+func (u HTMLEscaper) Type() string {
+	return "encoders"
+}


### PR DESCRIPTION
Add an additional encoder/decoder for HTML escaping:

```
:~$ echo '<script>alert(1);<script>' | ./pencode htmlescape ; echo
&lt;script&gt;alert(1);&lt;script&gt;
:~$ echo '&lt;script&gt;alert(1);&lt;script&gt;' | ./pencode htmlunescape ; echo
<script>alert(1);<script>
```