### PR TITLE
Remove deprecated goreleaser rules

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,13 +31,7 @@ builds:
       - goos: darwin
         goarch: 386
 archives:
-  - replacements:
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    id: tgz
+  - id: tgz
     format: tar.gz
     format_overrides:
       - goos: windows


### PR DESCRIPTION
Recent Goreleaser build deprecated archive name replacement rules. This PR removes them from the goreleaser configuration.